### PR TITLE
Adding separate endpoint for explicitly patching comments, disallowin…

### DIFF
--- a/app/scripts/controllers/statblock.js
+++ b/app/scripts/controllers/statblock.js
@@ -53,7 +53,7 @@ angular.module('sheetApp')
 
 			// now save character
 			$scope.character.modified = new Date();
-			$scope.character.saveOrUpdate();
+			$scope.character.updateComments();
 		};
 
 		$scope.deleteComment = function (c) {
@@ -66,7 +66,7 @@ angular.module('sheetApp')
 
 					// save character
 					$scope.character.modified = new Date();
-					$scope.character.saveOrUpdate();
+					$scope.character.updateComments();
 				}
 			}
 		};

--- a/app/scripts/services/character.js
+++ b/app/scripts/services/character.js
@@ -9,6 +9,10 @@ angular.module('sheetApp')
 				{ id: '@_id' }, { update: { method: 'PUT' } }
 			);
 
+			var commentResource = $resource('/api/v1/characters/:id/comment',
+				{ id: '@_id' }, { update: { method: 'PATCH' } }
+			);
+
 			resource.getById = function (id, cb, errorcb) {
 				return resource.get({ id: id }, cb, errorcb);
 			};
@@ -24,6 +28,12 @@ angular.module('sheetApp')
 					return this.$save(savecb, errorSavecb);
 				}
 			};
+
+			resource.prototype.updateComments = function (savecb, updatecb, errorSavecb, errorUpdatecb) {
+				if (this._id) {
+					return commentResource.update({ id: this._id }, angular.extend({}, this, { _id: undefined }), updatecb, errorUpdatecb);
+				}
+			}
 
 			resource.prototype.remove = function (cb, errorcb) {
 				return resource.remove({ id: this._id }, cb, errorcb);

--- a/server/web.js
+++ b/server/web.js
@@ -201,7 +201,6 @@ app.put(apiBase + '/characters/:id', ensureAuthenticated, function (req, res, ne
 	if (req.body.user && req.body.user.id) {
 		query(async (col, client) => {
 			try {
-				console.log(req.body);
 				// Currently logged in user's information gets pulled from sheetuser cookie
 				const user = JSON.parse(req.cookies.sheetuser);
 				const { id: userId, provider: userProvider } = user;


### PR DESCRIPTION
…g any other character modification unless user is authorized as creator of said character.

We make use of the creator information passed to use in req.body, and compare it to the information stored in the sheetuser cookie.  If they don't match, we reject any attempts to edit with a 403.

We don't want to restrict the GET endpoint, as this is also used for sharing of a character's information.  This means that the user will still be able to open a character's information in editable sheet form, but any changes made will throw a 403 and cause a redirect back to login.

Because comments are also done by editing the character, I've added a PATCH endpoint to specifically update the character's comments.  This explicitly extracts the comments key from req.body, and only modifies that single key.  This endpoint does not require that the user adding or deleting the comments be the same as the creator.  This is perhaps not ideal, but since we haven't had a concept of comments being linked with specific accounts, it isn't really a regression.

What this amounts to is - a user can still open an edit sheet that is not their own.  However, making edits to this sheet is not allowed unless they are the creator of the character.  This also applies to archiving and deleting of a character, as all of those actually go through that same PUT endpoint.

I did have a question, as I want to make sure I'm visualizing things properly.  Right now we've got a `/collections/characters/:id` DELETE endpoint that I don't see being used anywhere.  Do we have plans for that?  I'd initially thought that's where character deletion is handled.

Thanks so much once more for taking the time to review this. This should, at least in some way, address #24 .