### PR TITLE
Use fuzzy checking to authenticate users for database update

### DIFF
--- a/server/web.js
+++ b/server/web.js
@@ -208,7 +208,7 @@ app.put(apiBase + '/characters/:id', ensureAuthenticated, function (req, res, ne
 				// when we call `angular.extend`
 				const { id: creatorId, provider: creatorProvider } = req.body.user;
 				// Diff the ID's (and the providers, to be safe) to see if there's a discrepency
-				if (userId !== creatorId || userProvider !== creatorProvider) {
+				if (userId.toString() !== creatorId.toString() || userProvider !== creatorProvider) {
 					return res.send(403);
 				}
 				const r = await col.findOneAndUpdate(


### PR DESCRIPTION
Didn't realize in #91 that updating the database required another check of the user id. Casting both ids (in the browser and in the database) to strings resolves the issue of different type ids.

Fixes #92 