### PR TITLE
Force https

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,8 +10,8 @@
 		<meta name="description" content="An online character sheet for the Pathfinder Roleplaying Game, with cloud storage.">
 		<meta name="viewport" content="width=1010">
 		<script src="https://apis.google.com/js/api:client.js"></script>
-		<link href="http://fonts.googleapis.com/css?family=Goudy+Bookletter+1911&v1" rel="stylesheet" type="text/css">
-		<link href="http://fonts.googleapis.com/css?family=Caudex:regular,bold&v1" rel="stylesheet" type="text/css">
+		<link href="https://fonts.googleapis.com/css?family=Goudy+Bookletter+1911&v1" rel="stylesheet" type="text/css">
+		<link href="https://fonts.googleapis.com/css?family=Caudex:regular,bold&v1" rel="stylesheet" type="text/css">
 		<!-- build:css({.tmp,app}) styles/main.css -->
 		<link rel="stylesheet" href="bower_components/ngDialog/css/ngDialog.css">
 		<link rel="stylesheet" href="bower_components/ngDialog/css/ngDialog-theme-plain.css">

--- a/dist/index.html
+++ b/dist/index.html
@@ -10,8 +10,8 @@
 		<meta name="description" content="An online character sheet for the Pathfinder Roleplaying Game, with cloud storage.">
 		<meta name="viewport" content="width=1010">
 		<script src="https://apis.google.com/js/api:client.js"></script>
-		<link href="http://fonts.googleapis.com/css?family=Goudy+Bookletter+1911&v1" rel="stylesheet" type="text/css">
-		<link href="http://fonts.googleapis.com/css?family=Caudex:regular,bold&v1" rel="stylesheet" type="text/css">
+		<link href="https://fonts.googleapis.com/css?family=Goudy+Bookletter+1911&v1" rel="stylesheet" type="text/css">
+		<link href="https://fonts.googleapis.com/css?family=Caudex:regular,bold&v1" rel="stylesheet" type="text/css">
 		<link rel="stylesheet" href="styles/cedd436f.main.css"/>
 	</head>
 	<body ng-app="sheetApp" ng-class="controllerName">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2778,6 +2778,11 @@
         }
       }
     },
+    "express-sslify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-sslify/-/express-sslify-1.2.0.tgz",
+      "integrity": "sha1-MOhLzu0VV+sYdnK74UMKCioQDZw="
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "express": "^3.21.2",
     "express-session": "^1.16.1",
+    "express-sslify": "^1.2.0",
     "google-auth-library": "^3.1.0",
     "logfmt": "~0.21.0",
     "memorystore": "^1.6.1",

--- a/server/web.js
+++ b/server/web.js
@@ -4,6 +4,7 @@ var MemoryStore = require('memorystore')(session);
 var logfmt = require('logfmt');
 var _ = require('underscore');
 var { OAuth2Client } = require('google-auth-library');
+var enforce = require('express-sslify');
 var app = express();
 
 var mongoUri = process.env.DB_URI,
@@ -59,6 +60,7 @@ function (accessToken, refreshToken, profile, done) {
 
 // --- Configuration ---
 
+app.use(enforce.HTTPS({ trustProtoHeader: true })); // must be first
 app.use(logfmt.requestLogger());
 app.use(express.cookieParser());
 app.use(express.json()); // this, urlencoded, and multipart supercede bodyParser


### PR DESCRIPTION
Enforce SSL to align with Google's requirement for HTTPS for OAuth. Closes #94.

We could probably do this by writing the middleware ourselves, but I'm not familiar with working on webapps so this seems to be the safer option. It would make local development more difficult, however.